### PR TITLE
Update Github Action Only On Pull Request Activities

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,6 +1,8 @@
-name: GitHub Actions Demo
+name: Build, Lint And Test
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
-on: [push]
+on:
+    pull_request_target:
+      types: [opened, synchronize, reopened]
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want to only run this workflow in the context of pull requests. So, narrowing the triggers to pull request open, synchronize and reopened. 

