### PR TITLE
Ignore EXE/PDB Files 

### DIFF
--- a/.github/workflows/linux-build-test-lint.yml
+++ b/.github/workflows/linux-build-test-lint.yml
@@ -15,4 +15,5 @@ jobs:
       - run: go version
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -y 1
       - run: clang -v
+      - run: gcc --version
       - run: ruby code/programs/ruby/monorepo_build/build.rb

--- a/.github/workflows/mac-build-test-lint.yml
+++ b/.github/workflows/mac-build-test-lint.yml
@@ -17,4 +17,5 @@ jobs:
       - run: brew install rust
       - run: rustc --help
       - run: clang -v
+      - run: gcc --version
       - run: ruby code/programs/ruby/monorepo_build/build.rb

--- a/.github/workflows/windows-build-test-lint.yml
+++ b/.github/workflows/windows-build-test-lint.yml
@@ -16,4 +16,6 @@ jobs:
       - run: choco install rust
       - run: choco install llvm
       - run: clang -v
+      - run: choco install mingw
+      - run: gcc --version
       - run: ruby code/programs/ruby/monorepo_build/build.rb

--- a/code/programs/c/hello_world/.gitignore
+++ b/code/programs/c/hello_world/.gitignore
@@ -1,1 +1,3 @@
 hello_world
+hello_world.exe
+hello_world.pdb

--- a/code/programs/rust/hello_world/.gitignore
+++ b/code/programs/rust/hello_world/.gitignore
@@ -1,1 +1,3 @@
 hello_world
+hello_world.exe
+hello_world.pdb


### PR DESCRIPTION
In Windows, exe is the extension for executable files. This was not included in the previous .gitignore file. Similarly, Rust generates PDB files for debugging purposes. So, that has to be excluded as well. 