### PR TITLE
Enable Fortran Build On Windows

### DIFF
--- a/code/programs/fortran/hello_world/BUILD_windows
+++ b/code/programs/fortran/hello_world/BUILD_windows
@@ -1,0 +1,2 @@
+gfortran -o hello_world hello_world.f90
+./hello_world


### PR DESCRIPTION
I forgot to add the build file necessary for Fortran on Windows. So, fixing that. 