### PR TITLE
Enable GCC Build For C Code Using GCC

### DIFF
--- a/code/programs/c/hello_world/BUILD_mac
+++ b/code/programs/c/hello_world/BUILD_mac
@@ -1,2 +1,4 @@
 clang hello_world.c -o hello_world
 ./hello_world
+gcc hello_world.c -o hello_world2
+./hello_world2


### PR DESCRIPTION
I want all the C code I write to built and tested by the three major C compilers - Clang, GCC and MSVC. This PR incrementally adds support for GCC compilation on Mac. 