### PR TITLE
Enable GCC Builds For C In Windows

### DIFF
--- a/code/programs/c/hello_world/BUILD_windows
+++ b/code/programs/c/hello_world/BUILD_windows
@@ -1,5 +1,5 @@
-clang hello_world.c -o hello_world
+clang hello_world.c -o hello_world.exe
 dir
 .\hello_world.exe
-gcc hello_world.c -o hello_world2
+gcc hello_world.c -o hello_world2.exe
 .\hello_world2.exe

--- a/code/programs/c/hello_world/BUILD_windows
+++ b/code/programs/c/hello_world/BUILD_windows
@@ -1,2 +1,4 @@
 clang hello_world.c -o hello_world
 ./hello_world
+gcc hello_world.c -o hello_world2
+./hello_world2

--- a/code/programs/c/hello_world/BUILD_windows
+++ b/code/programs/c/hello_world/BUILD_windows
@@ -1,4 +1,4 @@
 clang hello_world.c -o hello_world
-.\hello_world
+hello_world.exe
 gcc hello_world.c -o hello_world2
-.\hello_world2
+.\hello_world2.exe

--- a/code/programs/c/hello_world/BUILD_windows
+++ b/code/programs/c/hello_world/BUILD_windows
@@ -1,5 +1,4 @@
 clang hello_world.c -o hello_world.exe
-dir
 .\hello_world.exe
 gcc hello_world.c -o hello_world2.exe
 .\hello_world2.exe

--- a/code/programs/c/hello_world/BUILD_windows
+++ b/code/programs/c/hello_world/BUILD_windows
@@ -1,4 +1,4 @@
 clang hello_world.c -o hello_world
-hello_world.exe
+.\hello_world.exe
 gcc hello_world.c -o hello_world2
 .\hello_world2.exe

--- a/code/programs/c/hello_world/BUILD_windows
+++ b/code/programs/c/hello_world/BUILD_windows
@@ -1,4 +1,4 @@
 clang hello_world.c -o hello_world
-./hello_world
+.\hello_world
 gcc hello_world.c -o hello_world2
-./hello_world2
+.\hello_world2

--- a/code/programs/c/hello_world/BUILD_windows
+++ b/code/programs/c/hello_world/BUILD_windows
@@ -1,4 +1,5 @@
 clang hello_world.c -o hello_world
+dir
 .\hello_world.exe
 gcc hello_world.c -o hello_world2
 .\hello_world2.exe


### PR DESCRIPTION
GCC is available on Windows through MingW. So, enabling GCC build for C files in Windows. 