### PR TITLE
Use CMD Instead Of PowerShell To Execute Windows Build Script

### DIFF
--- a/.github/workflows/windows-build-test-lint.yml
+++ b/.github/workflows/windows-build-test-lint.yml
@@ -34,7 +34,6 @@ jobs:
           dotnet --help
           choco install lua
           choco install r
-          Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
           refreshenv
           lua -v
           npm install -g typescript

--- a/.github/workflows/windows-build-test-lint.yml
+++ b/.github/workflows/windows-build-test-lint.yml
@@ -19,23 +19,25 @@ jobs:
       - name: Installing necessary software and running the build script
         shell: cmd
         run: |
-          go version
           choco install rust
           choco install llvm
-          clang -v
           choco install mingw
-          gcc --version
           choco install erlang
           choco install gnucobol
           choco install strawberryperl
           choco install haskell-dev
           choco install openjdk
           choco install zig
-          dotnet --help
           choco install lua
           choco install r
-          lua -v
           npm install -g typescript
           npm install -g deno
           npm install -g bun
+          SET "PATH=%PATH%;C:\ProgramData\chocolatey\bin"
+          echo %PATH%
+          lua -v
+          dotnet --help
+          gcc --version
+          clang -v
+          go version
           ruby code\programs\ruby\monorepo_build\build.rb

--- a/.github/workflows/windows-build-test-lint.yml
+++ b/.github/workflows/windows-build-test-lint.yml
@@ -17,7 +17,7 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
       - name: Installing necessary software and running the build script
-        shell: pwsh
+        shell: cmd
         run: |
           go version
           choco install rust

--- a/.github/workflows/windows-build-test-lint.yml
+++ b/.github/workflows/windows-build-test-lint.yml
@@ -30,7 +30,6 @@ jobs:
           choco install zig
           choco install lua
           choco install r
-          echo Attempting to Set Updated Path
           SET "PATH=%PATH%;C:\ProgramData\chocolatey\bin"
           echo %PATH%
           lua -v
@@ -38,4 +37,7 @@ jobs:
           gcc --version
           clang -v
           go version
+          npm install -g typescript
+          npm install -g deno
+          npm install -g bun
           ruby code\programs\ruby\monorepo_build\build.rb

--- a/.github/workflows/windows-build-test-lint.yml
+++ b/.github/workflows/windows-build-test-lint.yml
@@ -30,9 +30,7 @@ jobs:
           choco install zig
           choco install lua
           choco install r
-          npm install -g typescript
-          npm install -g deno
-          npm install -g bun
+          echo Attempting to Set Updated Path
           SET "PATH=%PATH%;C:\ProgramData\chocolatey\bin"
           echo %PATH%
           lua -v

--- a/.github/workflows/windows-build-test-lint.yml
+++ b/.github/workflows/windows-build-test-lint.yml
@@ -34,7 +34,6 @@ jobs:
           dotnet --help
           choco install lua
           choco install r
-          refreshenv
           lua -v
           npm install -g typescript
           npm install -g deno


### PR DESCRIPTION
Many of Windows tools are not PowerShell friendly. So, I am going to use cmd instead of PowerShell for build script. 