### PR TITLE
Stop Aliasing GCC To Clang In Mac

### DIFF
--- a/.github/workflows/mac-build-test-lint.yml
+++ b/.github/workflows/mac-build-test-lint.yml
@@ -17,7 +17,8 @@ jobs:
       - run: brew install rust
       - run: rustc --help
       - run: clang -v
-      - run: gcc --version
+      - run: brew install gcc
+      - run: gcc-13 --version
       - run: brew install gfortran
       - run: brew install erlang
       - run: brew install gnucobol

--- a/code/programs/c/hello_world/BUILD_mac
+++ b/code/programs/c/hello_world/BUILD_mac
@@ -1,4 +1,4 @@
 clang hello_world.c -o hello_world
 ./hello_world
-gcc hello_world.c -o hello_world2
+gcc-13 hello_world.c -o hello_world2
 ./hello_world2


### PR DESCRIPTION
`gcc` is simply an alias to `clang` on Mac. I want to compile with real `gcc`. So, installing `gcc` through Homebrew and using that compile the current `hello_world` program. 