### PR TITLE
Move Mac C Program Build To CMake

### DIFF
--- a/.github/workflows/mac-build-test-lint.yml
+++ b/.github/workflows/mac-build-test-lint.yml
@@ -39,4 +39,5 @@ jobs:
       - run: npm install -g esy
       - run: esy --version
       - run: swift --version
+      - run: cmake --version
       - run: ruby code/programs/ruby/monorepo_build/build.rb

--- a/code/programs/c/hello_world/BUILD_mac
+++ b/code/programs/c/hello_world/BUILD_mac
@@ -1,4 +1,7 @@
-clang hello_world.c -o hello_world
-./hello_world
-gcc-13 hello_world.c -o hello_world2
-./hello_world2
+cmake -B build-apple
+cmake --build build-apple
+./build-apple/bin-appleclang/hello-world-appleclang
+gcc-13 --version
+cmake -B build-gcc -DCMAKE_C_COMPILER=$(which gcc-13)
+cmake --build build-gcc
+./build-gcc/bin-gnu/hello-world-gnu


### PR DESCRIPTION
A previous PR to move linux C build to CMake was successful. Now moving Mac build to CMake. 