### PR TITLE
Remove Dotnet Backports PPA From Linux

### DIFF
--- a/.github/workflows/linux-build-test-lint.yml
+++ b/.github/workflows/linux-build-test-lint.yml
@@ -26,7 +26,7 @@ jobs:
       - run: sudo apt-get update
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '9.0.x'
       - run: dotnet --help
       - run: sudo apt-get install r-base-core
       - run: sudo apt-get install lua5.4 liblua5.4-dev

--- a/.github/workflows/linux-build-test-lint.yml
+++ b/.github/workflows/linux-build-test-lint.yml
@@ -26,7 +26,7 @@ jobs:
       - run: sudo apt-get update
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
       - run: dotnet --help
       - run: sudo apt-get install r-base-core
       - run: sudo apt-get install lua5.4 liblua5.4-dev

--- a/.github/workflows/linux-build-test-lint.yml
+++ b/.github/workflows/linux-build-test-lint.yml
@@ -24,7 +24,12 @@ jobs:
       - run: sudo apt-get install openjdk-17-jre
       - run: sudo snap install zig --classic --beta
       - run: sudo apt-get update
-      - run: sudo apt-get install -y dotnet-sdk-9.0
+      - name: Install .NET SDK
+        run: |
+          wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
+          chmod +x ./dotnet-install.sh
+          ./dotnet-install.sh --version latest  --install-dir $HOME/dotnet
+          echo "$HOME/dotnet" >> $GITHUB_PATH
       - run: dotnet --help
       - run: sudo apt-get install r-base-core
       - run: sudo apt-get install lua5.4 liblua5.4-dev

--- a/.github/workflows/linux-build-test-lint.yml
+++ b/.github/workflows/linux-build-test-lint.yml
@@ -23,7 +23,6 @@ jobs:
       - run: sudo apt-get install openjdk-17-jdk
       - run: sudo apt-get install openjdk-17-jre
       - run: sudo snap install zig --classic --beta
-      - run: sudo add-apt-repository ppa:dotnet/backports
       - run: sudo apt-get update
       - run: sudo apt-get install -y dotnet-sdk-9.0
       - run: dotnet --help

--- a/.github/workflows/linux-build-test-lint.yml
+++ b/.github/workflows/linux-build-test-lint.yml
@@ -24,12 +24,9 @@ jobs:
       - run: sudo apt-get install openjdk-17-jre
       - run: sudo snap install zig --classic --beta
       - run: sudo apt-get update
-      - name: Install .NET SDK
-        run: |
-          wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
-          chmod +x ./dotnet-install.sh
-          ./dotnet-install.sh --version latest  --install-dir $HOME/dotnet
-          echo "$HOME/dotnet" >> $GITHUB_PATH
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '3.1.x'
       - run: dotnet --help
       - run: sudo apt-get install r-base-core
       - run: sudo apt-get install lua5.4 liblua5.4-dev

--- a/code/programs/csharp/HelloWorld/HelloWorld.csproj
+++ b/code/programs/csharp/HelloWorld/HelloWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/code/programs/csharp/HelloWorld/HelloWorld.csproj
+++ b/code/programs/csharp/HelloWorld/HelloWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Dotnet backports PPA constantly fails. I took a look at the `dotnet` installation steps and it looks like it is no longer needed if I am going to make `9.0` the base version. So, removing the step. 