### PR TITLE
Refactor Context For Dependency Injection

### DIFF
--- a/code/programs/ruby/DIRS
+++ b/code/programs/ruby/DIRS
@@ -1,2 +1,3 @@
 hello_world
 virtual_machine
+monorepo_build

--- a/code/programs/ruby/monorepo_build/BUILD
+++ b/code/programs/ruby/monorepo_build/BUILD
@@ -1,0 +1,2 @@
+ruby test/test_file_processing_history.rb
+ruby test/test_build_context.rb

--- a/code/programs/ruby/monorepo_build/build.rb
+++ b/code/programs/ruby/monorepo_build/build.rb
@@ -1,6 +1,7 @@
 require 'open3'
-require 'set' # Used for tracking processed DIRS files AND for path de-duplication
-require 'pathname' # Needed by MSVC setup code
+require 'pathname'
+require_relative 'lib/build_context'
+require_relative 'lib/file_processing_history'
 
 puts "[INFO] Starting the build process..."
 
@@ -8,28 +9,19 @@ puts "[INFO] Starting the build process..."
 # MSVC Environment Setup Code (for Windows)
 # ==================================================
 
-# --- Helper Functions for MSVC Setup ---
-
-# Simple function to find vswhere (adjust path if necessary)
 def find_vswhere
-  # Standard location in Program Files (x86)
   vswhere_path = Pathname.new(ENV['ProgramFiles(x86)']) / 'Microsoft Visual Studio' / 'Installer' / 'vswhere.exe'
   return vswhere_path.to_s if vswhere_path.exist?
 
-  # Maybe it's already in PATH?
-  # Simple check; a more robust check would search PATH directories.
   output, status = Open3.capture2('where vswhere.exe')
   return output.lines.first.strip if status.success? && !output.empty?
 
   raise "vswhere.exe not found at standard location or in PATH. Cannot locate Visual Studio."
 end
 
-# Finds the vcvarsall.bat script using vswhere
-# vs_version: e.g., '17.0' for VS 2022, '16.0' for VS 2019, or nil for latest
 def find_vcvarsall(vs_version = nil)
   vswhere_exe = find_vswhere
 
-  # Base command arguments for vswhere
   cmd = [
     vswhere_exe,
     '-property', 'installationPath',
@@ -56,7 +48,6 @@ def find_vcvarsall(vs_version = nil)
   vcvarsall.to_s
 end
 
-# Parses the output of the 'set' command into a Hash
 def parse_env(set_output_lines)
   env_hash = {}
   set_output_lines.each do |line|
@@ -68,38 +59,24 @@ def parse_env(set_output_lines)
   env_hash
 end
 
-# Checks if a variable name typically holds path list
 def is_path_variable?(name)
   name.match?(/^(PATH|LIB|INCLUDE|LIBPATH)$/i)
 end
 
-# Cleans up path variables by removing duplicate entries
 def filter_path_value(path_string)
   Set.new(path_string.split(';').reject(&:empty?)).to_a.join(';')
 end
 
-
-# --- Main Function to Setup MSVC Environment ---
-# arch: e.g., "x64", "x86", "arm64"
-# sdk: e.g., "10.0.19041.0" (optional)
-# toolset: e.g., "14.38" (optional, corresponds to -vcvars_ver)
-# uwp: boolean (optional, adds 'uwp' argument)
-# spectre: boolean (optional, adds '-vcvars_spectre_libs=spectre')
-# vs_version: e.g., "17.0" (optional, for find_vcvarsall)
 def setup_msvc_env(arch: 'x64', sdk: nil, toolset: nil, uwp: false, spectre: false, vs_version: nil)
-  # 1. Platform already checked before calling this function
-
-  # 2. Find vcvarsall.bat
   begin
     vcvarsall_path = find_vcvarsall(vs_version)
     puts "[INFO] MSVC: Found vcvarsall.bat at: #{vcvarsall_path}"
   rescue => e
     puts "[ERR] MSVC: Failed to find vcvarsall.bat: #{e.message}"
-    raise # Re-raise the exception to halt the script (fail fast)
+    raise
   end
 
-  # 3. Construct vcvarsall arguments
-  vcvars_args = [arch] # Architecture is required
+  vcvars_args = [arch]
   vcvars_args << 'uwp' if uwp
   vcvars_args << sdk if sdk
   vcvars_args << "-vcvars_ver=#{toolset}" if toolset
@@ -108,20 +85,17 @@ def setup_msvc_env(arch: 'x64', sdk: nil, toolset: nil, uwp: false, spectre: fal
   vcvars_command = %("#{vcvarsall_path}" #{vcvars_args.join(' ')})
   puts "[INFO] MSVC: vcvars command line: #{vcvars_command}"
 
-  # 4. Execute the core command to capture environment changes
   full_command = "set && cls && #{vcvars_command} && cls && set"
   puts "[DEBUG] MSVC: Executing: #{full_command}"
   output, status = Open3.capture2e("cmd /c \"#{full_command}\"")
 
   unless status.success?
-      puts "[WARN] MSVC: Environment capture command execution might have failed. Status: #{status.exitstatus}"
-      puts "[WARN] MSVC: Output was:\n#{output}"
-      # Fail fast if the capture command itself fails significantly
-      raise "Failed to execute MSVC environment capture command. Status: #{status.exitstatus}" if status.exitstatus != 0
+    puts "[WARN] MSVC: Environment capture command execution might have failed. Status: #{status.exitstatus}"
+    puts "[WARN] MSVC: Output was:\n#{output}"
+    raise "Failed to execute MSVC environment capture command. Status: #{status.exitstatus}" if status.exitstatus != 0
   end
 
-  # 5. Parse the output
-  output_parts = output.split("\f") # Split by the form feed from cls
+  output_parts = output.split("\f")
   unless output_parts.length == 3
     puts "[ERR] MSVC: Unexpected output format when splitting by form feed (cls)."
     puts "[ERR] MSVC: Expected 3 parts, got #{output_parts.length}."
@@ -130,10 +104,9 @@ def setup_msvc_env(arch: 'x64', sdk: nil, toolset: nil, uwp: false, spectre: fal
   end
 
   before_env_lines = output_parts[0].lines
-  vcvars_out_lines = output_parts[1].lines # Messages from vcvarsall itself
+  vcvars_out_lines = output_parts[1].lines
   after_env_lines  = output_parts[2].lines
 
-  # 6. Check vcvarsall output for errors
   error_messages = vcvars_out_lines.map(&:strip).select do |line|
     line.match?(/^\[ERROR.*\]/i) && !line.match?(/Error in script usage. The correct usage is:/)
   end
@@ -144,7 +117,6 @@ def setup_msvc_env(arch: 'x64', sdk: nil, toolset: nil, uwp: false, spectre: fal
     raise "vcvarsall.bat failed with errors. See log for details."
   end
 
-  # 7. Parse environments and diff
   puts "[INFO] MSVC: Processing environment variables..."
   before_env = parse_env(before_env_lines)
   after_env = parse_env(after_env_lines)
@@ -168,7 +140,6 @@ def setup_msvc_env(arch: 'x64', sdk: nil, toolset: nil, uwp: false, spectre: fal
                       new_value
                     end
 
-      # 8. Apply Changes to Current Ruby Process Environment (ENV hash)
       ENV[key] = final_value
     end
   end
@@ -176,27 +147,20 @@ def setup_msvc_env(arch: 'x64', sdk: nil, toolset: nil, uwp: false, spectre: fal
   puts "[INFO] MSVC: Environment configured successfully."
   puts "[INFO] MSVC: #{new_vars} new variables, #{changed_vars} changed variables applied to current process environment."
 end
+
 # ==================================================
 # End of MSVC Environment Setup Code
 # ==================================================
-
 
 # --- Configuration ---
 BUILD_FILE_PATTERN = /^BUILD(?:_windows|_mac_and_linux|_mac|_linux)?$/
 DIRS_FILE_NAME = "DIRS"
 BUILD_COMMENT_CHAR = '#'
 
-# --- Global State ---
-# Keep track of processed DIRS files to avoid cycles
-$processed_dirs_files = Set.new
+# --- Helper Functions ---
 
-# --- Helper Functions (Your Existing Helpers) ---
-
-# Function to execute a single shell command
-# Exits script immediately on failure.
 def execute_command(command, current_working_directory)
   puts "[CMD] In '#{current_working_directory}': #{command}"
-  # Pass the current ENV which now includes MSVC vars if on Windows
   stdout_str, stderr_str, status = Open3.capture3(ENV, command, chdir: current_working_directory)
 
   if status.success?
@@ -204,46 +168,41 @@ def execute_command(command, current_working_directory)
   else
     puts "[ERR] Command failed! (Exit Status: #{status.exitstatus})"
     puts "[ERR] #{stderr_str.strip}" unless stderr_str.strip.empty?
-    exit(status.exitstatus) # FAIL FAST: Exit with the command's status
+    exit(status.exitstatus)
   end
 rescue => e
-  # Catch errors like command not found
   puts "[ERR] Failed to execute command '#{command}' in '#{current_working_directory}': #{e.message}"
-  exit(1) # FAIL FAST: Exit with a generic error code
+  exit(1)
 end
 
-# Function to check if the build file should run on the current OS
 def check_os_match(build_file_path)
-    filename = File.basename(build_file_path)
-    # Use more robust check for Windows platform variants
-    is_windows = RUBY_PLATFORM.match?(/mingw|mswin/i)
-    is_mac = RUBY_PLATFORM.include?("darwin")
-    is_linux = !is_windows && !is_mac && RUBY_PLATFORM.include?("linux") # Be more specific for Linux
+  filename = File.basename(build_file_path)
+  is_windows = RUBY_PLATFORM.match?(/mingw|mswin/i)
+  is_mac = RUBY_PLATFORM.include?("darwin")
+  is_linux = !is_windows && !is_mac && RUBY_PLATFORM.include?("linux")
 
-    case filename
-    when /_windows$/
-      is_windows
-    when /_mac_and_linux$/
-      is_mac || is_linux
-    when /_mac$/
-      is_mac
-    when /_linux$/
-      is_linux
-    else # BUILD file without suffix runs everywhere
-      true
-    end
+  case filename
+  when /_windows$/
+    is_windows
+  when /_mac_and_linux$/
+    is_mac || is_linux
+  when /_mac$/
+    is_mac
+  when /_linux$/
+    is_linux
+  else
+    true
+  end
 end
 
-# --- Core Processing Functions (Your Existing Functions) ---
+# --- Core Processing Functions ---
 
-# Processes a BUILD file, executing its commands.
-# Will exit script via execute_command on first failure.
 def process_build_file(build_file_path)
   absolute_path = File.absolute_path(build_file_path)
 
   unless check_os_match(absolute_path)
     puts "[INFO] Skipping BUILD file #{File.basename(absolute_path)} in #{File.dirname(absolute_path)} due to OS mismatch."
-    return # Not an error, just skip
+    return
   end
 
   puts "[INFO] Processing BUILD file: #{absolute_path}"
@@ -253,32 +212,26 @@ def process_build_file(build_file_path)
     build_file_contents = File.readlines(absolute_path)
     build_file_contents.each_with_index do |line, index|
       command = line.strip
-      # Skip empty lines and comments
       next if command.empty? || command.start_with?(BUILD_COMMENT_CHAR)
-      # execute_command will exit immediately if it fails
-      # It automatically uses the updated ENV
       execute_command(command, current_directory)
     end
   rescue Errno::ENOENT
     puts "[ERR] Build file not found: #{absolute_path}"
-    exit(1) # FAIL FAST
+    exit(1)
   rescue => e
     puts "[ERR] Error reading build file #{absolute_path}: #{e.message}"
-    exit(1) # FAIL FAST
+    exit(1)
   end
 end
 
-# Processes a DIRS file, recursively processing items in listed subdirectories.
-# Will exit script via recursive calls if any failure occurs.
-def process_dirs_file(dirs_file_path)
+def process_dirs_file(dirs_file_path, context)
   absolute_path = File.absolute_path(dirs_file_path)
 
-  # Prevent infinite loops
-  if $processed_dirs_files.include?(absolute_path)
-     puts "[WARN] Already processed DIRS file #{absolute_path}, skipping to prevent infinite loop."
-     return # Not an error
+  if context.file_processing_history.already_processed?(absolute_path)
+    puts "[WARN] Already processed DIRS file #{absolute_path}, skipping to prevent infinite loop."
+    return
   end
-  $processed_dirs_files.add(absolute_path)
+  context.file_processing_history.mark_processed(absolute_path)
 
   puts "[INFO] Processing DIRS file: #{absolute_path}"
   current_directory = File.dirname(absolute_path)
@@ -293,12 +246,9 @@ def process_dirs_file(dirs_file_path)
 
       unless Dir.exist?(full_next_dir_path)
         puts "[WARN] Directory '#{full_next_dir_path}' listed in #{absolute_path} not found. Skipping."
-        next # Skip this entry
+        next
       end
 
-      # Scan the listed directory for BUILD or DIRS files
-      # Avoid puts clutter here unless necessary, focus on processing
-      # puts "[INFO] Scanning directory: #{full_next_dir_path}"
       Dir.foreach(full_next_dir_path) do |entry|
         next if entry == '.' || entry == '..'
         full_entry_path = File.join(full_next_dir_path, entry)
@@ -307,34 +257,28 @@ def process_dirs_file(dirs_file_path)
           filename = File.basename(full_entry_path)
 
           if filename == DIRS_FILE_NAME
-            # Recursive call - will exit if failure occurs within
-            process_dirs_file(full_entry_path)
+            process_dirs_file(full_entry_path, context)
           elsif filename.match?(BUILD_FILE_PATTERN)
-            # Process BUILD - will exit if failure occurs within
             process_build_file(full_entry_path)
           end
         end
-      end # End Dir.foreach
-    end # End dirs_file_contents.each
-
+      end
+    end
   rescue Errno::ENOENT
     puts "[ERR] DIRS file not found: #{absolute_path}"
-    exit(1) # FAIL FAST
+    exit(1)
   rescue => e
     puts "[ERR] Error reading DIRS file #{absolute_path}: #{e.message}"
-    exit(1) # FAIL FAST
+    exit(1)
   end
 end
 
 # --- Main Execution Logic ---
 
-# ** SETUP MSVC ENV IF ON WINDOWS **
 begin
   if RUBY_PLATFORM.match?(/mingw|mswin/i)
     puts "[INFO] Windows platform detected. Attempting MSVC environment setup..."
-    # Call the setup function - use defaults or specify options
-    # e.g., setup_msvc_env(arch: 'x64', vs_version: '17.0')
-    setup_msvc_env() # Using defaults (likely latest VS, x64)
+    setup_msvc_env()
     puts "[INFO] MSVC environment setup complete. Continuing build."
   else
     puts "[INFO] Non-Windows platform detected. Skipping MSVC setup."
@@ -342,9 +286,8 @@ begin
 rescue => e
   puts "[FATAL ERR] Failed during MSVC environment setup: #{e.message}"
   puts e.backtrace.join("\n")
-  exit(1) # Fail fast if MSVC setup fails
+  exit(1)
 end
-# ************************************
 
 # --- Shortcut Mode: Build a Single BUILD File ---
 if ARGV.length == 1
@@ -366,34 +309,28 @@ end
 start_directory = Dir.pwd
 puts "[INFO] Starting build scan in: #{start_directory}"
 
-begin
-  # Initial scan of the top-level directory
-  Dir.foreach(start_directory) do |entry|
-     next if entry == '.' || entry == '..'
-     entry_path = File.join(start_directory, entry)
+context = BuildContext.new
 
-     if File.file?(entry_path)
-       filename = File.basename(entry_path)
-       if filename == DIRS_FILE_NAME
-         process_dirs_file(entry_path) # Start recursion
-       elsif filename.match?(BUILD_FILE_PATTERN)
-         process_build_file(entry_path) # Process top-level build file
-       end
-     elsif File.directory?(entry_path)
-       # Optional: If you want to scan subdirs even without a top-level DIRS
-       # you might add logic here, but based on your script, it seems
-       # driven entirely by DIRS files after the initial scan.
-     end
+begin
+  Dir.foreach(start_directory) do |entry|
+    next if entry == '.' || entry == '..'
+    entry_path = File.join(start_directory, entry)
+
+    if File.file?(entry_path)
+      filename = File.basename(entry_path)
+      if filename == DIRS_FILE_NAME
+        process_dirs_file(entry_path, context)
+      elsif filename.match?(BUILD_FILE_PATTERN)
+        process_build_file(entry_path)
+      end
+    end
   end
 rescue => e
-   # Catch unexpected errors during the initial scan itself
-   puts "[ERR] An unexpected error occurred during initial scan: #{e.message}"
-   puts e.backtrace.join("\n")
-   exit(1) # FAIL FAST
+  puts "[ERR] An unexpected error occurred during initial scan: #{e.message}"
+  puts e.backtrace.join("\n")
+  exit(1)
 end
 
-# --- Final Status ---
-# If the script reaches this point, everything succeeded
 puts "\n--------------------------------"
 puts "[INFO] Build finished successfully."
 exit(0)

--- a/code/programs/ruby/monorepo_build/lib/build_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/build_context.rb
@@ -1,0 +1,9 @@
+require_relative 'file_processing_history'
+
+class BuildContext
+  attr_reader :file_processing_history
+
+  def initialize
+    @file_processing_history = FileProcessingHistory.new
+  end
+end

--- a/code/programs/ruby/monorepo_build/lib/build_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/build_context.rb
@@ -3,7 +3,7 @@ require_relative 'file_processing_history'
 class BuildContext
   attr_reader :file_processing_history
 
-  def initialize
-    @file_processing_history = FileProcessingHistory.new
+  def initialize(file_processing_history:)
+    @file_processing_history = file_processing_history
   end
 end

--- a/code/programs/ruby/monorepo_build/lib/file_processing_history.rb
+++ b/code/programs/ruby/monorepo_build/lib/file_processing_history.rb
@@ -1,0 +1,15 @@
+require 'set'
+
+class FileProcessingHistory
+  def initialize
+    @processed_files = Set.new
+  end
+
+  def already_processed?(path)
+    @processed_files.include?(path)
+  end
+
+  def mark_processed(path)
+    @processed_files.add(path)
+  end
+end

--- a/code/programs/ruby/monorepo_build/lib/get_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/get_context.rb
@@ -1,0 +1,7 @@
+require_relative 'file_processing_history'
+require_relative 'build_context'
+
+def get_context
+  file_history = FileProcessingHistory.new
+  BuildContext.new(file_processing_history: file_history)
+end

--- a/code/programs/ruby/monorepo_build/test/test_build_context.rb
+++ b/code/programs/ruby/monorepo_build/test/test_build_context.rb
@@ -1,0 +1,19 @@
+require 'minitest/autorun'
+require_relative '../lib/build_context'
+
+class BuildContextTest < Minitest::Test
+  def setup
+    @context = BuildContext.new
+  end
+
+  def test_file_processing_history_exists
+    assert_instance_of FileProcessingHistory, @context.file_processing_history
+  end
+
+  def test_file_processing_history_behavior
+    path = 'some/build/file'
+    refute @context.file_processing_history.already_processed?(path)
+    @context.file_processing_history.mark_processed(path)
+    assert @context.file_processing_history.already_processed?(path)
+  end
+end

--- a/code/programs/ruby/monorepo_build/test/test_build_context.rb
+++ b/code/programs/ruby/monorepo_build/test/test_build_context.rb
@@ -1,9 +1,10 @@
 require 'minitest/autorun'
 require_relative '../lib/build_context'
+require_relative '../lib/file_processing_history'
 
 class BuildContextTest < Minitest::Test
   def setup
-    @context = BuildContext.new
+    @context = BuildContext.new(file_processing_history: FileProcessingHistory.new)
   end
 
   def test_file_processing_history_exists

--- a/code/programs/ruby/monorepo_build/test/test_file_processing_history.rb
+++ b/code/programs/ruby/monorepo_build/test/test_file_processing_history.rb
@@ -1,0 +1,25 @@
+require 'minitest/autorun'
+require_relative '../lib/file_processing_history'
+
+class FileProcessingHistoryTest < Minitest::Test
+  def setup
+    @history = FileProcessingHistory.new
+  end
+
+  def test_initially_not_processed
+    refute @history.already_processed?('some/path')
+  end
+
+  def test_mark_and_check_processed
+    @history.mark_processed('some/path')
+    assert @history.already_processed?('some/path')
+  end
+
+  def test_mark_multiple_paths
+    @history.mark_processed('path/one')
+    @history.mark_processed('path/two')
+    assert @history.already_processed?('path/one')
+    assert @history.already_processed?('path/two')
+    refute @history.already_processed?('path/three')
+  end
+end


### PR DESCRIPTION
We are currently constructing FileProcessingHistory object inline in BuildContext. I want this code to be easily unit tested. So, refactoring the code to take in FileProcessingHistory object rather than constructing it. 