### PR TITLE
Add Rubocop To Toolchain

### DIFF
--- a/.github/workflows/linux-build-test-lint.yml
+++ b/.github/workflows/linux-build-test-lint.yml
@@ -64,4 +64,5 @@ jobs:
       - run: composer -v
       - run: sudo apt-get install ninja-build
       - run: sudo apt-get -y install podman
+      - run: sudo gem install rubocop --no-document
       - run: ruby code/programs/ruby/monorepo_build/build.rb

--- a/.github/workflows/mac-build-test-lint.yml
+++ b/.github/workflows/mac-build-test-lint.yml
@@ -57,4 +57,5 @@ jobs:
       - run: cmake --version
       - run: brew install ninja
       - run: ninja --version
+      - run: gem install rubocop --no-document
       - run: ruby code/programs/ruby/monorepo_build/build.rb

--- a/.github/workflows/windows-build-test-lint.yml
+++ b/.github/workflows/windows-build-test-lint.yml
@@ -53,4 +53,5 @@ jobs:
           cmake --version
           choco install ninja
           ninja --version
+          gem install rubocop --no-document
           ruby code\programs\ruby\monorepo_build\build.rb


### PR DESCRIPTION
I want to start enforcing Rubocop for all the Ruby code in this repo. So, adding it to the repo and toolchain. 