### PR TITLE
Always Print Stdout

### DIFF
--- a/code/programs/ruby/monorepo_build/build.rb
+++ b/code/programs/ruby/monorepo_build/build.rb
@@ -162,9 +162,9 @@ def execute_command(command, current_working_directory)
   puts "[CMD] In '#{current_working_directory}': #{command}"
   stdout_str, stderr_str, status = Open3.capture3(ENV, command, chdir: current_working_directory)
 
-  if status.success?
-    puts "[OUT] #{stdout_str.strip}" unless stdout_str.strip.empty?
-  else
+  puts "[OUT] #{stdout_str.strip}" unless stdout_str.strip.empty?
+
+  unless status.success?
     puts "[ERR] Command failed! (Exit Status: #{status.exitstatus})"
     puts "[ERR] #{stderr_str.strip}" unless stderr_str.strip.empty?
     exit(status.exitstatus)


### PR DESCRIPTION
I am observing that all the context that is printed out via stdout when we encounter an error. So, I am making sure that stdout is always printed. 