### PR TITLE
Introduce Exit Handler Abstraction

### DIFF
--- a/code/programs/ruby/monorepo_build/build.rb
+++ b/code/programs/ruby/monorepo_build/build.rb
@@ -153,11 +153,11 @@ def execute_command(context, command, current_working_directory)
   unless status.success?
     context.logger.error("Command failed! (Exit Status: #{status.exitstatus})")
     context.logger.error(stderr_str.strip) unless stderr_str.strip.empty?
-    exit(status.exitstatus)
+    context.exit_handler.exit(status.exitstatus)
   end
 rescue => e
   context.logger.error("Failed to execute command '#{command}' in '#{current_working_directory}': #{e.message}")
-  exit(1)
+  context.exit_handler.exit(1)
 end
 
 def check_os_match(build_file_path)
@@ -192,17 +192,17 @@ def process_build_file(context, build_file_path)
   current_directory = File.dirname(absolute_path)
 
   begin
-    File.readlines(absolute_path).each_with_index do |line, _index|
+    File.readlines(absolute_path).each do |line|
       command = line.strip
       next if command.empty? || command.start_with?(BUILD_COMMENT_CHAR)
       execute_command(context, command, current_directory)
     end
   rescue Errno::ENOENT
     context.logger.error("Build file not found: #{absolute_path}")
-    exit(1)
+    context.exit_handler.exit(1)
   rescue => e
     context.logger.error("Error reading build file #{absolute_path}: #{e.message}")
-    exit(1)
+    context.exit_handler.exit(1)
   end
 end
 
@@ -245,10 +245,10 @@ def process_dirs_file(context, dirs_file_path)
     end
   rescue Errno::ENOENT
     context.logger.error("DIRS file not found: #{absolute_path}")
-    exit(1)
+    context.exit_handler.exit(1)
   rescue => e
     context.logger.error("Error reading DIRS file #{absolute_path}: #{e.message}")
-    exit(1)
+    context.exit_handler.exit(1)
   end
 end
 
@@ -267,7 +267,7 @@ begin
 rescue => e
   context.logger.fatal("Failed during MSVC environment setup: #{e.message}")
   context.logger.fatal(e.backtrace.join("\n"))
-  exit(1)
+  context.exit_handler.exit(1)
 end
 
 if ARGV.length == 1
@@ -279,10 +279,10 @@ if ARGV.length == 1
     process_build_file(context, absolute_path)
     context.logger.info('--------------------------------')
     context.logger.info('Single BUILD file finished successfully.')
-    exit(0)
+    context.exit_handler.exit(0)
   else
     context.logger.error("Provided path is not a valid BUILD file: #{user_provided_path}")
-    exit(1)
+    context.exit_handler.exit(1)
   end
 end
 
@@ -306,9 +306,9 @@ begin
 rescue => e
   context.logger.error("An unexpected error occurred during initial scan: #{e.message}")
   context.logger.error(e.backtrace.join("\n"))
-  exit(1)
+  context.exit_handler.exit(1)
 end
 
 context.logger.info('--------------------------------')
 context.logger.info('Build finished successfully.')
-exit(0)
+context.exit_handler.exit(0)

--- a/code/programs/ruby/monorepo_build/build.rb
+++ b/code/programs/ruby/monorepo_build/build.rb
@@ -153,11 +153,11 @@ def execute_command(context, command, current_working_directory)
   unless status.success?
     context.logger.error("Command failed! (Exit Status: #{status.exitstatus})")
     context.logger.error(stderr_str.strip) unless stderr_str.strip.empty?
-    context.exit_handler.exit(status.exitstatus)
+    context.exit_handler.exit_with_code(status.exitstatus)
   end
 rescue => e
   context.logger.error("Failed to execute command '#{command}' in '#{current_working_directory}': #{e.message}")
-  context.exit_handler.exit(1)
+  context.exit_handler.exit_with_code(1)
 end
 
 def check_os_match(build_file_path)
@@ -199,10 +199,10 @@ def process_build_file(context, build_file_path)
     end
   rescue Errno::ENOENT
     context.logger.error("Build file not found: #{absolute_path}")
-    context.exit_handler.exit(1)
+    context.exit_handler.exit_with_code(1)
   rescue => e
     context.logger.error("Error reading build file #{absolute_path}: #{e.message}")
-    context.exit_handler.exit(1)
+    context.exit_handler.exit_with_code(1)
   end
 end
 
@@ -245,10 +245,10 @@ def process_dirs_file(context, dirs_file_path)
     end
   rescue Errno::ENOENT
     context.logger.error("DIRS file not found: #{absolute_path}")
-    context.exit_handler.exit(1)
+    context.exit_handler.exit_with_code(1)
   rescue => e
     context.logger.error("Error reading DIRS file #{absolute_path}: #{e.message}")
-    context.exit_handler.exit(1)
+    context.exit_handler.exit_with_code(1)
   end
 end
 
@@ -267,7 +267,7 @@ begin
 rescue => e
   context.logger.fatal("Failed during MSVC environment setup: #{e.message}")
   context.logger.fatal(e.backtrace.join("\n"))
-  context.exit_handler.exit(1)
+  context.exit_handler.exit_with_code(1)
 end
 
 if ARGV.length == 1
@@ -279,10 +279,10 @@ if ARGV.length == 1
     process_build_file(context, absolute_path)
     context.logger.info('--------------------------------')
     context.logger.info('Single BUILD file finished successfully.')
-    context.exit_handler.exit(0)
+    context.exit_handler.exit_with_code(0)
   else
     context.logger.error("Provided path is not a valid BUILD file: #{user_provided_path}")
-    context.exit_handler.exit(1)
+    context.exit_handler.exit_with_code(1)
   end
 end
 
@@ -306,9 +306,9 @@ begin
 rescue => e
   context.logger.error("An unexpected error occurred during initial scan: #{e.message}")
   context.logger.error(e.backtrace.join("\n"))
-  context.exit_handler.exit(1)
+  context.exit_handler.exit_with_code(1)
 end
 
 context.logger.info('--------------------------------')
 context.logger.info('Build finished successfully.')
-context.exit_handler.exit(0)
+context.exit_handler.exit_with_code(0)

--- a/code/programs/ruby/monorepo_build/lib/build_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/build_context.rb
@@ -1,8 +1,9 @@
 class BuildContext
-  attr_reader :file_processing_history, :logger
+  attr_reader :file_processing_history, :logger, :exit_handler
 
-  def initialize(file_processing_history:, logger:)
+  def initialize(file_processing_history:, logger:, exit_handler:)
     @file_processing_history = file_processing_history
     @logger = logger
+    @exit_handler = exit_handler
   end
 end

--- a/code/programs/ruby/monorepo_build/lib/exit_handler.rb
+++ b/code/programs/ruby/monorepo_build/lib/exit_handler.rb
@@ -1,0 +1,5 @@
+class ExitHandler
+  def exit_with_code(code)
+    Kernel.exit(code)
+  end
+end

--- a/code/programs/ruby/monorepo_build/lib/get_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/get_context.rb
@@ -3,10 +3,11 @@ require_relative 'file_processing_history'
 require_relative 'default_standard_stream_log_processor'
 require_relative 'logger'
 require_relative 'exit_handler'
+require_relative 'build_context'
 
 def get_context
   log_processor = default_standard_stream_log_processor
-  logger = Logger.new(log_processor)
+  logger = Logger.new(processor: log_processor)
   file_processing_history = FileProcessingHistory.new
   exit_handler = ExitHandler.new
 

--- a/code/programs/ruby/monorepo_build/lib/get_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/get_context.rb
@@ -5,7 +5,7 @@ require_relative 'logger'
 require_relative 'exit_handler'
 
 def get_context
-  log_processor = DefaultStandardStreamLogProcessor.new
+  log_processor = default_standard_stream_log_processor
   logger = Logger.new(log_processor)
   file_processing_history = FileProcessingHistory.new
   exit_handler = ExitHandler.new

--- a/code/programs/ruby/monorepo_build/lib/get_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/get_context.rb
@@ -1,12 +1,18 @@
+# lib/get_context.rb
 require_relative 'file_processing_history'
-require_relative 'build_context'
+require_relative 'default_standard_stream_log_processor'
 require_relative 'logger'
-require_relative "default_standard_stream_log_processor"
+require_relative 'exit_handler'
 
 def get_context
-  logger = Logger.new(processor: default_standard_stream_log_processor)
+  log_processor = DefaultStandardStreamLogProcessor.new
+  logger = Logger.new(log_processor)
+  file_processing_history = FileProcessingHistory.new
+  exit_handler = ExitHandler.new
+
   BuildContext.new(
-    file_processing_history: FileProcessingHistory.new,
-    logger: logger
+    file_processing_history: file_processing_history,
+    logger: logger,
+    exit_handler: exit_handler
   )
 end

--- a/code/programs/ruby/monorepo_build/test/test_build_context.rb
+++ b/code/programs/ruby/monorepo_build/test/test_build_context.rb
@@ -2,15 +2,20 @@ require 'minitest/autorun'
 require_relative '../lib/build_context'
 require_relative '../lib/file_processing_history'
 require_relative '../lib/logger'
+require_relative '../lib/exit_handler'
 require_relative "memory_processor"
 
 class BuildContextTest < Minitest::Test
   def setup
     processor = MemoryProcessor.new
     logger = Logger.new(processor: processor)
+    file_processing_history = FileProcessingHistory.new
+    exit_handler = ExitHandler.new
+
     @context = BuildContext.new(
-      file_processing_history: FileProcessingHistory.new,
-      logger: logger
+      file_processing_history: file_processing_history,
+      logger: logger,
+      exit_handler: exit_handler
     )
   end
 


### PR DESCRIPTION
There is no way to unit test the exit logic at the moment without calling `exit` directly. So, I am introducing an abstraction called `ExitHandler`. 