### PR TITLE
Trap Exceptions/Errors Inside Command Runner

### DIFF
--- a/code/programs/ruby/monorepo_build/lib/command_runner.rb
+++ b/code/programs/ruby/monorepo_build/lib/command_runner.rb
@@ -1,9 +1,30 @@
 require 'open3'
 require_relative 'command_result'
+require_relative 'fake_failure_status'
 
 class CommandRunner
+  def initialize(logger)
+    @logger = logger
+  end
+
   def run_command(command, chdir: nil)
-    stdout, stderr, status = Open3.capture3(command, chdir: chdir)
+    location_info = chdir ? " in #{chdir}" : ""
+    @logger.info("Executing command: #{command}#{location_info}")
+
+    begin
+      stdout, stderr, status = Open3.capture3(command, chdir: chdir)
+    rescue => e
+      @logger.warn("Exception while executing command: #{e.message}")
+      stdout = ''
+      stderr = e.message
+      status = FakeFailureStatus.new
+    end
+
+    unless status.success?
+      @logger.error("Command failed with status #{status.exitstatus}: #{command}")
+      @logger.error("Stderr: #{stderr}") unless stderr.to_s.strip.empty?
+    end
+
     CommandResult.new(stdout: stdout, stderr: stderr, status: status)
   end
 end

--- a/code/programs/ruby/monorepo_build/lib/fake_failure_status.rb
+++ b/code/programs/ruby/monorepo_build/lib/fake_failure_status.rb
@@ -1,0 +1,9 @@
+class FakeFailureStatus
+  def success?
+    false
+  end
+
+  def exitstatus
+    1
+  end
+end

--- a/code/programs/ruby/monorepo_build/lib/get_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/get_context.rb
@@ -13,7 +13,7 @@ def get_context
   file_processing_history = FileProcessingHistory.new
   exit_handler = ExitHandler.new
   env = EnvAccessor.new
-  command_runner = CommandRunner.new
+  command_runner = CommandRunner.new(logger)
 
   BuildContext.new(
     file_processing_history: file_processing_history,

--- a/code/programs/ruby/monorepo_build/test/test_build_context.rb
+++ b/code/programs/ruby/monorepo_build/test/test_build_context.rb
@@ -14,7 +14,7 @@ class BuildContextTest < Minitest::Test
     file_processing_history = FileProcessingHistory.new
     exit_handler = ExitHandler.new
     env = EnvAccessor.new
-    command_runner = CommandRunner.new
+    command_runner = CommandRunner.new(logger)
 
     @context = BuildContext.new(
       file_processing_history: file_processing_history,


### PR DESCRIPTION
I want to move to a spot where exceptions don't escape abstractions. Starting this concept in the CommandRunner. Adding logs and trapping exceptions. 