### PR TITLE
Extract find_vswhere Function And Add UTs

### DIFF
--- a/code/programs/ruby/monorepo_build/BUILD
+++ b/code/programs/ruby/monorepo_build/BUILD
@@ -2,3 +2,4 @@ ruby test/test_file_processing_history.rb
 ruby test/test_build_context.rb
 ruby test/test_logger.rb
 ruby test/test_standard_stream_log_processor.rb
+ruby test/test_find_vswhere.rb

--- a/code/programs/ruby/monorepo_build/build.rb
+++ b/code/programs/ruby/monorepo_build/build.rb
@@ -3,7 +3,7 @@ require 'set'
 require 'pathname'
 
 require_relative 'lib/get_context'
-require_relative 'lib/errors/msvc/vswhere_not_found_error'
+require_relative 'lib/find_vswhere'
 
 # --- Configuration ---
 BUILD_FILE_PATTERN = /^BUILD(?:_windows|_mac_and_linux|_mac|_linux)?$/
@@ -13,16 +13,6 @@ BUILD_COMMENT_CHAR = '#'
 # ==================================================
 # MSVC Environment Setup Code (for Windows)
 # ==================================================
-
-def find_vswhere(context)
-  vswhere_path = Pathname.new(context.env['ProgramFiles(x86)']) / 'Microsoft Visual Studio' / 'Installer' / 'vswhere.exe'
-  return vswhere_path.to_s if vswhere_path.exist?
-
-  result = context.command_runner.run('where vswhere.exe')
-  return result.stdout.lines.first.strip if result.success? && !result.stdout.strip.empty?
-
-  raise VswhereNotFoundError
-end
 
 def find_vcvarsall(context, vs_version = nil)
   vswhere_exe = find_vswhere(context)

--- a/code/programs/ruby/monorepo_build/lib/build_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/build_context.rb
@@ -1,11 +1,12 @@
 class BuildContext
-  attr_reader :file_processing_history, :logger, :exit_handler, :env, :command_runner
+  attr_reader :file_processing_history, :logger, :exit_handler, :env, :command_runner, :path_resolver
 
-  def initialize(file_processing_history:, logger:, exit_handler:, env:, command_runner:)
+  def initialize(file_processing_history:, logger:, exit_handler:, env:, command_runner:, path_resolver: nil)
     @file_processing_history = file_processing_history
     @logger = logger
     @exit_handler = exit_handler
     @env = env
     @command_runner = command_runner
+    @path_resolver = path_resolver
   end
 end

--- a/code/programs/ruby/monorepo_build/lib/find_vswhere.rb
+++ b/code/programs/ruby/monorepo_build/lib/find_vswhere.rb
@@ -1,0 +1,26 @@
+require_relative 'errors/msvc/vswhere_not_found_error'
+
+def find_vswhere(context)
+  base = context.env['ProgramFiles(x86)']
+  context.logger.info("Attempting to construct vswhere path using ProgramFiles(x86): #{base}")
+
+  vswhere_path = context.path_resolver.join_path(base, 'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
+  context.logger.info("Resolved vswhere path to: #{vswhere_path}")
+
+  if context.path_resolver.path_exists?(vswhere_path)
+    context.logger.info("vswhere.exe found at constructed path: #{vswhere_path}")
+    return vswhere_path.to_s
+  end
+
+  context.logger.warn("vswhere.exe not found at default path. Falling back to 'where vswhere.exe'")
+
+  result = context.command_runner.run_command('where vswhere.exe')
+  if result.success? && !result.stdout.strip.empty?
+    found_path = result.stdout.lines.first.strip
+    context.logger.info("Found vswhere.exe via 'where': #{found_path}")
+    return found_path
+  end
+
+  context.logger.error("vswhere.exe could not be found via default path or 'where' command.")
+  raise VswhereNotFoundError
+end

--- a/code/programs/ruby/monorepo_build/lib/get_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/get_context.rb
@@ -6,20 +6,35 @@ require_relative 'exit_handler'
 require_relative 'build_context'
 require_relative 'env_accessor'
 require_relative 'command_runner'
+require_relative 'path_resolver'
 
-def get_context
-  log_processor = default_standard_stream_log_processor
-  logger = Logger.new(processor: log_processor)
-  file_processing_history = FileProcessingHistory.new
-  exit_handler = ExitHandler.new
-  env = EnvAccessor.new
-  command_runner = CommandRunner.new(logger)
+def get_context(
+  logger_to_override: nil,
+  exit_handler_to_override: nil,
+  command_runner_to_override: nil,
+  env_accessor_to_override: nil,
+  path_resolver_to_override: nil,
+  file_processing_history_to_override: nil
+)
+  logger = if logger_to_override
+             logger_to_override
+           else
+             log_processor = default_standard_stream_log_processor
+             Logger.new(processor: log_processor)
+           end
+
+  exit_handler = exit_handler_to_override || ExitHandler.new
+  command_runner = command_runner_to_override || CommandRunner.new(logger: logger)
+  env_accessor = env_accessor_to_override || EnvAccessor.new
+  path_resolver = path_resolver_to_override || PathResolver.new
+  file_processing_history = file_processing_history_to_override || FileProcessingHistory.new
 
   BuildContext.new(
     file_processing_history: file_processing_history,
     logger: logger,
     exit_handler: exit_handler,
-    env: env,
-    command_runner: command_runner
+    command_runner: command_runner,
+    env: env_accessor,
+    path_resolver: path_resolver
   )
 end

--- a/code/programs/ruby/monorepo_build/lib/path_resolver.rb
+++ b/code/programs/ruby/monorepo_build/lib/path_resolver.rb
@@ -1,0 +1,11 @@
+require 'pathname'
+
+class PathResolver
+  def join_path(*parts)
+    Pathname.new(File.join(*parts))
+  end
+
+  def path_exists?(path)
+    Pathname.new(path).exist?
+  end
+end

--- a/code/programs/ruby/monorepo_build/test/mocks/command_result_mock.rb
+++ b/code/programs/ruby/monorepo_build/test/mocks/command_result_mock.rb
@@ -1,0 +1,13 @@
+class CommandResultMock
+  attr_reader :stdout, :stderr, :success
+
+  def initialize(stdout:, stderr:, success:)
+    @stdout = stdout
+    @stderr = stderr
+    @success = success
+  end
+
+  def success?
+    @success
+  end
+end

--- a/code/programs/ruby/monorepo_build/test/mocks/command_runner_mock.rb
+++ b/code/programs/ruby/monorepo_build/test/mocks/command_runner_mock.rb
@@ -1,0 +1,12 @@
+class CommandRunnerMock
+  attr_reader :called
+  def initialize(mock_result)
+    @mock_result = mock_result
+    @called = false
+  end
+
+  def run_command(command)
+    @called = true
+    @mock_result
+  end
+end

--- a/code/programs/ruby/monorepo_build/test/mocks/path_resolver_mock.rb
+++ b/code/programs/ruby/monorepo_build/test/mocks/path_resolver_mock.rb
@@ -1,0 +1,13 @@
+class PathResolverMock
+  def initialize(path_exists:)
+    @path_exists = path_exists
+  end
+
+  def join_path(*segments)
+    File.join(*segments)
+  end
+
+  def path_exists?(path)
+    @path_exists
+  end
+end

--- a/code/programs/ruby/monorepo_build/test/stubs/env_accessor_stub.rb
+++ b/code/programs/ruby/monorepo_build/test/stubs/env_accessor_stub.rb
@@ -1,0 +1,9 @@
+class EnvAccessorStub
+  def [](key)
+    # Simulate ENV['ProgramFiles(x86)']
+    'C:/MockProgramFiles'
+  end
+  def key?(key)
+    true
+  end
+end

--- a/code/programs/ruby/monorepo_build/test/stubs/logger_stub.rb
+++ b/code/programs/ruby/monorepo_build/test/stubs/logger_stub.rb
@@ -1,0 +1,7 @@
+class LoggerStub
+  def info(message); end
+  def warn(message); end
+  def error(message); end
+  def fatal(message); end
+  def debug(message); end
+end

--- a/code/programs/ruby/monorepo_build/test/test_build_context.rb
+++ b/code/programs/ruby/monorepo_build/test/test_build_context.rb
@@ -5,6 +5,7 @@ require_relative '../lib/logger'
 require_relative '../lib/exit_handler'
 require_relative '../lib/env_accessor'
 require_relative '../lib/command_runner'
+require_relative '../lib/path_resolver'
 require_relative "memory_processor"
 
 class BuildContextTest < Minitest::Test
@@ -15,13 +16,15 @@ class BuildContextTest < Minitest::Test
     exit_handler = ExitHandler.new
     env = EnvAccessor.new
     command_runner = CommandRunner.new(logger)
+    path_resolver = PathResolver.new
 
     @context = BuildContext.new(
       file_processing_history: file_processing_history,
       logger: logger,
       exit_handler: exit_handler,
       env: env,
-      command_runner: command_runner
+      command_runner: command_runner,
+      path_resolver: path_resolver
     )
   end
 

--- a/code/programs/ruby/monorepo_build/test/test_find_vswhere.rb
+++ b/code/programs/ruby/monorepo_build/test/test_find_vswhere.rb
@@ -1,0 +1,97 @@
+require 'minitest/autorun'
+require_relative '../lib/get_context'
+require_relative '../lib/find_vswhere'
+require_relative '../lib/errors/msvc/vswhere_not_found_error'
+require_relative 'mocks/path_resolver_mock'
+require_relative 'mocks/command_runner_mock'
+require_relative 'mocks/command_result_mock'
+require_relative 'stubs/env_accessor_stub'
+require_relative 'stubs/logger_stub'
+
+class FindVswhereTest < Minitest::Test
+  def test_returns_path_if_vswhere_exists_directly
+    set_vswhere_path_exists = true # Simulate that vswhere.exe exists directly in the path
+    path_resolver = PathResolverMock.new(path_exists: set_vswhere_path_exists)
+    env = EnvAccessorStub.new
+    vswhere_command_path = "C:\\Mocked\\vswhere.exe\n" # Mocked output of the 'where' command
+    command_result_mock = CommandResultMock.new(success: false, stdout: vswhere_command_path, stderr: "")
+    command_runner = CommandRunnerMock.new(command_result_mock)
+    logger = LoggerStub.new
+
+    context = get_context(
+      path_resolver_to_override: path_resolver,
+      env_accessor_to_override: env,
+      command_runner_to_override: command_runner,
+      logger_to_override: logger
+    )
+
+    result = find_vswhere(context)
+    assert_equal command_runner.called, false # Ensure the command runner was not called
+  end
+
+  def test_uses_where_command_when_vswhere_not_in_path
+    set_vswhere_path_exists = false # Simulate that vswhere.exe does not exist directly in the path
+    path_resolver = PathResolverMock.new(path_exists: set_vswhere_path_exists)
+    env = EnvAccessorStub.new
+    set_vswhere_command_run_success = true # Simulate that the 'where' command runs successfully
+    vswhere_command_path = "C:\\Mocked\\vswhere.exe\n" # Mocked output of the 'where' command
+    command_result_mock = CommandResultMock.new(success: set_vswhere_command_run_success, stdout: vswhere_command_path, stderr: "")
+    command_runner = CommandRunnerMock.new(command_result_mock)
+    logger = LoggerStub.new
+
+    context = get_context(
+      path_resolver_to_override: path_resolver,
+      env_accessor_to_override: env,
+      command_runner_to_override: command_runner,
+      logger_to_override: logger
+    )
+
+    result = find_vswhere(context)
+    assert command_runner.called # Ensure the command runner was called
+  end
+
+  def test_raises_error_when_vswhere_not_found
+    set_vswhere_path_exists = false # Simulate that vswhere.exe does not exist directly in the path
+    path_resolver = PathResolverMock.new(path_exists: set_vswhere_path_exists)
+    env = EnvAccessorStub.new
+    set_vswhere_command_run_success = false # Simulate that the 'where' command fails
+    vswhere_command_path = "" # Mocked output of the 'where' command
+    command_result_mock = CommandResultMock.new(success: set_vswhere_command_run_success, stdout: vswhere_command_path, stderr: "Error")
+    command_runner = CommandRunnerMock.new(command_result_mock)
+    logger = LoggerStub.new
+
+    context = get_context(
+      path_resolver_to_override: path_resolver,
+      env_accessor_to_override: env,
+      command_runner_to_override: command_runner,
+      logger_to_override: logger
+    )
+
+    assert_raises(VswhereNotFoundError) do
+      find_vswhere(context)
+    end
+  end
+
+  def test_raises_error_when_vswhere_found_but_stdout_empty
+    set_vswhere_path_exists = false # Simulate that vswhere.exe does not exist directly in the path
+    path_resolver = PathResolverMock.new(path_exists: set_vswhere_path_exists)
+    env = EnvAccessorStub.new
+    set_vswhere_command_run_success = true # Simulate that the 'where' command runs successfully
+    vswhere_command_path = "" # Mocked output of the 'where' command
+    stdout_contents = "" # Simulate empty stdout
+    command_result_mock = CommandResultMock.new(success: set_vswhere_command_run_success, stdout: stdout_contents, stderr: "")
+    command_runner = CommandRunnerMock.new(command_result_mock)
+    logger = LoggerStub.new
+
+    context = get_context(
+      path_resolver_to_override: path_resolver,
+      env_accessor_to_override: env,
+      command_runner_to_override: command_runner,
+      logger_to_override: logger
+    )
+
+    assert_raises(VswhereNotFoundError) do
+      find_vswhere(context)
+    end
+  end
+end


### PR DESCRIPTION
I am continuing the refactor of the Ruby build script. In this PR, I am extracting the `find_vswhere` function which is used in Windows build. I am adding unit tests for the function for the first time. 