### PR TITLE
Add Scoop Package Manager To Github Actions

### DIFF
--- a/.github/workflows/windows-build-test-lint.yml
+++ b/.github/workflows/windows-build-test-lint.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Installing necessary software and running the build script
         shell: pwsh
         run: |
+          Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+          Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+          scoop help
           go version
           choco install rust
           choco install llvm


### PR DESCRIPTION
Many packages I have come across are only available to install through Scoop. So, adding the scoop package manager to Windows github actions. 