### PR TITLE
Add Build Context In Go Implementation

### DIFF
--- a/code/programs/go/monorepo_build/build_context.go
+++ b/code/programs/go/monorepo_build/build_context.go
@@ -1,0 +1,11 @@
+package main
+
+type BuildContext struct {
+	logger Logger
+}
+
+func GetBuildContext() BuildContext {
+	return BuildContext{
+		logger: TerminalLogger{},
+	}
+}

--- a/code/programs/go/monorepo_build/logger.go
+++ b/code/programs/go/monorepo_build/logger.go
@@ -1,0 +1,5 @@
+package main
+
+type Logger interface {
+	Info(msg string)
+}

--- a/code/programs/go/monorepo_build/main.go
+++ b/code/programs/go/monorepo_build/main.go
@@ -1,7 +1,6 @@
 package main
 
-import "fmt"
-
 func main() {
-	fmt.Println("Hello World!")
+	context := GetBuildContext()
+	context.logger.Info("Hello, world!")
 }

--- a/code/programs/go/monorepo_build/terminal_logger.go
+++ b/code/programs/go/monorepo_build/terminal_logger.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+type TerminalLogger struct{}
+
+func (TerminalLogger) Info(msg string) {
+	fmt.Println(msg)
+}


### PR DESCRIPTION
I am slowly re-implementing the current build script in Go. We currently use a build context to abstract away a lot of logic. So, adding a simple BuildContext struct and simple logger implementation. 