### PR TITLE
Add Command Line Arguments Provider

### DIFF
--- a/code/programs/ruby/monorepo_build/build.rb
+++ b/code/programs/ruby/monorepo_build/build.rb
@@ -261,8 +261,9 @@ rescue => e
   context.exit_handler.exit_with_code(1)
 end
 
-if ARGV.length == 1
-  user_provided_path = ARGV[0]
+arguments = context.command_line_arguments_provider.arguments
+if arguments.length == 1
+  user_provided_path = arguments[0]
   if File.file?(user_provided_path) && File.basename(user_provided_path).match?(BUILD_FILE_PATTERN)
     absolute_path = File.absolute_path(user_provided_path)
     context.logger.info('User requested single BUILD file execution:')

--- a/code/programs/ruby/monorepo_build/lib/build_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/build_context.rb
@@ -1,12 +1,13 @@
 class BuildContext
-  attr_reader :file_processing_history, :logger, :exit_handler, :env, :command_runner, :path_resolver
+  attr_reader :file_processing_history, :logger, :exit_handler, :env, :command_runner, :path_resolver, :command_line_arguments_provider
 
-  def initialize(file_processing_history:, logger:, exit_handler:, env:, command_runner:, path_resolver: nil)
+  def initialize(file_processing_history:, logger:, exit_handler:, env:, command_runner:, path_resolver:, command_line_arguments_provider:)
     @file_processing_history = file_processing_history
     @logger = logger
     @exit_handler = exit_handler
     @env = env
     @command_runner = command_runner
     @path_resolver = path_resolver
+    @command_line_arguments_provider = command_line_arguments_provider
   end
 end

--- a/code/programs/ruby/monorepo_build/lib/command_line_arguments_provider.rb
+++ b/code/programs/ruby/monorepo_build/lib/command_line_arguments_provider.rb
@@ -1,0 +1,5 @@
+class CommandLineArgumentsProvider
+  def arguments
+    raise NotImplementedError
+  end
+end

--- a/code/programs/ruby/monorepo_build/lib/default_command_line_arguments_provider.rb
+++ b/code/programs/ruby/monorepo_build/lib/default_command_line_arguments_provider.rb
@@ -1,0 +1,7 @@
+require_relative 'command_line_arguments_provider'
+
+class DefaultCommandLineArgumentsProvider < CommandLineArgumentsProvider
+  def arguments
+    ARGV.dup
+  end
+end

--- a/code/programs/ruby/monorepo_build/lib/get_context.rb
+++ b/code/programs/ruby/monorepo_build/lib/get_context.rb
@@ -7,6 +7,7 @@ require_relative 'build_context'
 require_relative 'env_accessor'
 require_relative 'command_runner'
 require_relative 'path_resolver'
+require_relative 'default_command_line_arguments_provider'
 
 def get_context(
   logger_to_override: nil,
@@ -14,7 +15,8 @@ def get_context(
   command_runner_to_override: nil,
   env_accessor_to_override: nil,
   path_resolver_to_override: nil,
-  file_processing_history_to_override: nil
+  file_processing_history_to_override: nil,
+  command_line_arguments_provider_to_override: nil
 )
   logger = if logger_to_override
              logger_to_override
@@ -28,6 +30,7 @@ def get_context(
   env_accessor = env_accessor_to_override || EnvAccessor.new
   path_resolver = path_resolver_to_override || PathResolver.new
   file_processing_history = file_processing_history_to_override || FileProcessingHistory.new
+  command_line_arguments_provider = command_line_arguments_provider_to_override || DefaultCommandLineArgumentsProvider.new
 
   BuildContext.new(
     file_processing_history: file_processing_history,
@@ -35,6 +38,7 @@ def get_context(
     exit_handler: exit_handler,
     command_runner: command_runner,
     env: env_accessor,
-    path_resolver: path_resolver
+    path_resolver: path_resolver,
+    command_line_arguments_provider: command_line_arguments_provider
   )
 end

--- a/code/programs/ruby/monorepo_build/test/stubs/command_line_arguments_provider_stub.rb
+++ b/code/programs/ruby/monorepo_build/test/stubs/command_line_arguments_provider_stub.rb
@@ -1,0 +1,5 @@
+class CommandLineArgumentsProviderStub
+  def arguments
+    ["--stub-arg1", "--stub-arg2"]
+  end
+end

--- a/code/programs/ruby/monorepo_build/test/test_build_context.rb
+++ b/code/programs/ruby/monorepo_build/test/test_build_context.rb
@@ -7,6 +7,7 @@ require_relative '../lib/env_accessor'
 require_relative '../lib/command_runner'
 require_relative '../lib/path_resolver'
 require_relative "memory_processor"
+require_relative "stubs/command_line_arguments_provider_stub"
 
 class BuildContextTest < Minitest::Test
   def setup
@@ -17,6 +18,7 @@ class BuildContextTest < Minitest::Test
     env = EnvAccessor.new
     command_runner = CommandRunner.new(logger)
     path_resolver = PathResolver.new
+    command_line_arguments_provider = CommandLineArgumentsProviderStub.new
 
     @context = BuildContext.new(
       file_processing_history: file_processing_history,
@@ -24,7 +26,8 @@ class BuildContextTest < Minitest::Test
       exit_handler: exit_handler,
       env: env,
       command_runner: command_runner,
-      path_resolver: path_resolver
+      path_resolver: path_resolver,
+      command_line_arguments_provider: command_line_arguments_provider
     )
   end
 


### PR DESCRIPTION
We are currently making use of `ARGV` directly. We need to abstract it away to make it unit testable in the future. 